### PR TITLE
Allow digit selection with Alt+<digit> keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ where you want to save the drawing: `draw masterpiece.txt`.
 * Press <kbd>5</kbd> for magenta.
 * Press <kbd>6</kbd> for cyan.
 * Press <kbd>7</kbd> for gray.
+* Press <kbd>Alt+0</kbd> - <kbd>Alt+9</kbd> to draw with digits.

--- a/draw.go
+++ b/draw.go
@@ -101,16 +101,22 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textAnchorDown()
 			}
 		default:
+			var character = msg.String()
+
+			if strings.HasPrefix(character, "alt+") {
+				character = character[4:]
+			}
+
 			if m.textAnchorIsSet() {
 				// If the textAnchor is set, we want to allow the user to
 				// insert text at the anchor.
 				style := lipgloss.NewStyle().Foreground(lipgloss.Color(m.color))
-				m.canvas[m.textAnchor.y][m.textAnchor.x] = style.Render(msg.String())
+				m.canvas[m.textAnchor.y][m.textAnchor.x] = style.Render(character)
 				m.textAnchorRight()
 			}
 			// Otherwise, we will want to change the character that is being
 			// used to the character that the user just typed.
-			m.character = msg.String()
+			m.character = character
 		}
 	}
 	return m, nil

--- a/draw.go
+++ b/draw.go
@@ -103,8 +103,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			var character = msg.String()
 
-			if strings.HasPrefix(character, "alt+") {
-				character = character[4:]
+			if msg.Alt {
+				character = string(msg.Runes[0])
 			}
 
 			if m.textAnchorIsSet() {


### PR DESCRIPTION
Fixes #11.

This PR introduces the way to select the digits as character that used to draw with `Alt+<digit>` keys. It also allows to type them when text anchor is set.
